### PR TITLE
Fix issue with alchemically-modified bonds and angles

### DIFF
--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -703,7 +703,7 @@ class AbsoluteAlchemicalFactory(object):
         force = openmm.HarmonicAngleForce()
 
         # Create CustomAngleForce to handle alchemically modified angles.
-        energy_function = "lambda_angles*(K/2)*(theta-theta0)**2)"
+        energy_function = "lambda_angles*(K/2)*(theta-theta0)^2)"
         custom_force = openmm.CustomAngleForce(energy_function)
         custom_force.addGlobalParameter('lambda_angles', 1.0)
         custom_force.addPerAngleParameter('theta0')
@@ -740,7 +740,7 @@ class AbsoluteAlchemicalFactory(object):
         force = openmm.HarmonicBondForce()
 
         # Create CustomBondForce to handle alchemically modified bonds.
-        energy_function = "lambda_bonds*(K/2)*(r-r0)**2)"
+        energy_function = "lambda_bonds*(K/2)*(r-r0)^2)"
         custom_force = openmm.CustomBondForce(energy_function)
         custom_force.addGlobalParameter('lambda_bonds', 1.0)
         custom_force.addPerBondParameter('r0')

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 from openmmtools import testsystems
 
-from .alchemy import AlchemicalState, AbsoluteAlchemicalFactory
+from alchemy import AlchemicalState, AbsoluteAlchemicalFactory
 
 from nose.plugins.skip import Skip, SkipTest
 

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 from openmmtools import testsystems
 
-from alchemy import AlchemicalState, AbsoluteAlchemicalFactory
+from .alchemy import AlchemicalState, AbsoluteAlchemicalFactory
 
 from nose.plugins.skip import Skip, SkipTest
 


### PR DESCRIPTION
There was a typo that caused alchemically-modiifed bonds and angles in `CustomBondForce` and `CustomAngleForce` to throw an exception.

Not sure why this was not caught previously.
