### PR TITLE
[WIP] Expose softcore parameters and improve default choices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ protocol = factory.defaultComplexProtocolImplicit()
 # Create the perturbed systems using this protocol.
 systems = factory.createPerturbedSystems(protocol)
 ```
+
+## Changelog
+
+### 1.2 - Expose softcore parameters as context parameters
+Alchemical softcore parameters are now exposed as context parameters, and can be tweaked on the fly.
+The default selection of softcore c was also changed.
+
+### 1.1 - Allow bonds, angles, and torsions to be alchemically softened
+This release allows specified bonds, angles, and torsions to be alchemically softened.
+1.1.1 was a critical bugfix release.
+
+### 1.0 - Initial release
+This release breaks out `alchemy.py` from the [`yank`](http://github.com/choderalab/yank) project

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/choderalab/alchemy.svg?branch=master)](https://travis-ci.org/choderalab/alchemy)
+[![Anaconda Badge](https://binstar.org/omnia/alchemy/badges/version.svg)](https://binstar.org/omnia/alchemy)
 
 # Alchemical tools for OpenMM
 

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -271,7 +271,10 @@ class AbsoluteAlchemicalFactory(object):
         alchemical_slave_functions : dict, optional, default=None
             If not None, this dict specifies a mapping from context parameters to one or more globally-controlled parameters.
             This allows groups of alchemical parameters to be slaved to one or more global context parameters.
-            default_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
+            To slave everything to a single lambda:
+              default_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
+            For a two-stage function:
+              default_functions = { 'lambda_sterics' : '2*lambda * step(0.5 - lambda)', 'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)' }
         test_positions : simtk.unit.Quantity of dimension (natoms,3) with units compatible with nanometers, optional, default=None
             If provided, these coordinates will be used to test alchemically-modified system to ensure the potential energy is finite.
             If the potential energy is NaN, the energy for each force component will be computed for the Reference platform to aid in debugging.

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -236,7 +236,7 @@ class AbsoluteAlchemicalFactory(object):
     def __init__(self, reference_system, ligand_atoms=list(), receptor_atoms=list(),
                  alchemical_torsions=None, alchemical_angles=None, alchemical_bonds=None,
                  annihilate_electrostatics=True, annihilate_sterics=False,
-                 softcore_alpha=0.5, softcore_beta=0.5, softcore_a=1, softcore_b=1, softcore_c=6, softcore_d=1, softcore_e=1, softcore_f=2,
+                 softcore_alpha=0.5, softcore_beta=0.5, softcore_a=1, softcore_b=1, softcore_c=6, softcore_d=2, softcore_e=2, softcore_f=1,
                  alchemical_functions=None,
                  test_positions=None, platform=None):
         """

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -274,13 +274,13 @@ class AbsoluteAlchemicalFactory(object):
         softcore_d, softcore_e, softcore_f : float, optional, default=1
             Parameters modifying softcore electrostatics form.
             r_eff = sigma*((softcore_beta*(lambda_electrostatics-1)^softcore_e + (r/sigma)^softcore_f))^(1/softcore_f)
-        alchemical_slave_functions : dict, optional, default=None
+        alchemical_functions : dict, optional, default=None
             If not None, this dict specifies a mapping from context parameters to one or more globally-controlled parameters.
             This allows groups of alchemical parameters to be slaved to one or more global context parameters.
             To slave everything to a single lambda:
-              default_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
+              alchemical_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
             For a two-stage function:
-              default_functions = { 'lambda_sterics' : '2*lambda * step(0.5 - lambda)', 'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)' }
+              alchemical_functions = { 'lambda_sterics' : '2*lambda * step(0.5 - lambda)', 'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)' }
         test_positions : simtk.unit.Quantity of dimension (natoms,3) with units compatible with nanometers, optional, default=None
             If provided, these coordinates will be used to test alchemically-modified system to ensure the potential energy is finite.
             If the potential energy is NaN, the energy for each force component will be computed for the Reference platform to aid in debugging.

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -236,7 +236,7 @@ class AbsoluteAlchemicalFactory(object):
     def __init__(self, reference_system, ligand_atoms=list(), receptor_atoms=list(),
                  alchemical_torsions=None, alchemical_angles=None, alchemical_bonds=None,
                  annihilate_electrostatics=True, annihilate_sterics=False,
-                 softcore_alpha=0.5, softcore_beta=0.5, softcore_a=1, softcore_b=1, softcore_c=6, softcore_d=2, softcore_e=2, softcore_f=1,
+                 softcore_alpha=0.5, softcore_beta=1.0, softcore_a=1, softcore_b=1, softcore_c=6, softcore_d=1, softcore_e=1, softcore_f=2,
                  alchemical_functions=None,
                  test_positions=None, platform=None):
         """

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -973,7 +973,7 @@ class AbsoluteAlchemicalFactory(object):
             force.addGlobalParameter('softcore_c', softcore_c)
         add_global_parameters(sterics_custom_nonbonded_force)
         add_global_parameters(electrostatics_custom_nonbonded_force)
-        add_gloabl_parameters(custom_bond_force)
+        add_global_parameters(custom_bond_force)
 
         return
 

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -816,10 +816,6 @@ class AbsoluteAlchemicalFactory(object):
 
         alchemical_atom_indices = self.ligand_atoms
 
-        # Promote to empty list
-        if software_context_parameters is None:
-            software_context_parameters = list()
-
         # Create a copy of the NonbondedForce to handle non-alchemical interactions.
         nonbonded_force = copy.deepcopy(reference_force)
         system.addForce(nonbonded_force)

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -566,6 +566,9 @@ test_systems = dict()
 test_systems['Lennard-Jones cluster'] = {
     'test' : testsystems.LennardJonesCluster(),
     'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2) }}
+test_systems['Lennard-Jones cluster with modified softcore parameters'] = {
+    'test' : testsystems.LennardJonesCluster(),
+    'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2), 'softcore_a' : 2, 'softcore_b' : 2, 'softcore_c' :2 }}
 test_systems['Lennard-Jones fluid without dispersion correction'] = {
     'test' : testsystems.LennardJonesFluid(dispersion_correction=False),
     'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2) }}
@@ -584,6 +587,9 @@ test_systems['TIP3P with reaction field, no switch, dispersion correction'] = {
 test_systems['TIP3P with reaction field, switch, dispersion correction'] = {
     'test' : testsystems.WaterBox(dispersion_correction=True, switch=True, nonbondedMethod=app.CutoffPeriodic),
     'factory_args' : {'ligand_atoms' : range(0,3), 'receptor_atoms' : range(3,6) }}
+test_systems['TIP3P with reaction field, switch, dispersion correctionm, electrostatics scaling followed by softcore Lennard-Jones'] = {
+    'test' : testsystems.WaterBox(dispersion_correction=True, switch=True, nonbondedMethod=app.CutoffPeriodic),
+    'factory_args' : {'ligand_atoms' : range(0,3), 'receptor_atoms' : range(3,6), 'softcore_beta' : 0.0, 'alchemical_functions' : { 'lambda_sterics' : '2*lambda * step(0.5 - lambda)', 'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)' }}}
 test_systems['alanine dipeptide in vacuum'] = {
     'test' : testsystems.AlanineDipeptideVacuum(),
     'factory_args' : {'ligand_atoms' : range(0,22), 'receptor_atoms' : range(22,22) }}

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -568,7 +568,7 @@ test_systems['Lennard-Jones cluster'] = {
     'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2) }}
 test_systems['Lennard-Jones cluster with modified softcore parameters'] = {
     'test' : testsystems.LennardJonesCluster(),
-    'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2), 'softcore_a' : 2, 'softcore_b' : 2, 'softcore_c' :2 }}
+    'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2), 'softcore_alpha' : 1, 'softcore_beta' : 1, 'softcore_a' : 2, 'softcore_b' : 2, 'softcore_c' : 2, 'softcore_d' : 2, 'softcore_e' : 2, 'softcore_f' : 2 }}
 test_systems['Lennard-Jones fluid without dispersion correction'] = {
     'test' : testsystems.LennardJonesFluid(dispersion_correction=False),
     'factory_args' : {'ligand_atoms' : range(0,1), 'receptor_atoms' : range(1,2) }}
@@ -701,7 +701,7 @@ def test_softcore_parameters():
     reference_system = test_system['test'].system
     positions = test_system['test'].positions
     factory_args = test_system['factory_args']
-    factory_args.update({ 'softcore_alpha' : 1.0, 'softcore_beta' : 0.0, 'softcore_a' : 1.0, 'softcore_b' : 1.0, 'softcore_c' : 1.0 })
+    factory_args.update({ 'softcore_alpha' : 1.0, 'softcore_beta' : 1.0, 'softcore_a' : 1.0, 'softcore_b' : 1.0, 'softcore_c' : 1.0, 'softcore_d' : 1.0, 'softcore_e' : 1.0, 'softcore_f' : 1.0 })
     factory = AbsoluteAlchemicalFactory(reference_system, **factory_args)
     alchemical_system = factory.createPerturbedSystem()
     compareSystemEnergies(positions, [reference_system, alchemical_system], ['reference', 'alchemical'])

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -15,6 +15,7 @@ Tests for alchemical factory in `alchemy.py`.
 
 import os, os.path
 import numpy as np
+import copy
 import time
 from functools import partial
 
@@ -664,6 +665,40 @@ overlap_testsystem_names = [
     'TIP3P with PME, no switch, no dispersion correction', # PME still lacks reciprocal space component; known energy comparison failure
     'toluene in implicit solvent',
 ]
+
+#=============================================================================================
+# Test various options to AbsoluteAlchemicalFactory
+#=============================================================================================
+
+def test_alchemical_functions():
+    """
+    Testing alchemical slave functions
+    """
+    alchemical_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
+    name = 'Lennard-Jones fluid with dispersion correction'
+    test_system = copy.deepcopy(test_systems[name])
+    reference_system = test_system['test'].system
+    positions = test_system['test'].positions
+    factory_args = test_system['factory_args']
+    factory_args['alchemical_functions'] = alchemical_functions
+    factory = AbsoluteAlchemicalFactory(reference_system, **factory_args)
+    alchemical_system = factory.createPerturbedSystem()
+    compareSystemEnergies(positions, [reference_system, alchemical_system], ['reference', 'alchemical'])
+
+def test_softcore_parameters():
+    """
+    Testing alchemical slave functions
+    """
+    alchemical_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
+    name = 'Lennard-Jones fluid with dispersion correction'
+    test_system = copy.deepcopy(test_systems[name])
+    reference_system = test_system['test'].system
+    positions = test_system['test'].positions
+    factory_args = test_system['factory_args']
+    factory_args.update({ 'softcore_alpha' : 1.0, 'softcore_beta' : 0.0, 'softcore_a' : 1.0, 'softcore_b' : 1.0, 'softcore_c' : 1.0 })
+    factory = AbsoluteAlchemicalFactory(reference_system, **factory_args)
+    alchemical_system = factory.createPerturbedSystem()
+    compareSystemEnergies(positions, [reference_system, alchemical_system], ['reference', 'alchemical'])
 
 #=============================================================================================
 # NOSETEST GENERATORS

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def find_package_data(data_root, package_root):
 
 
 # #########################
-VERSION = '1.1.4'
+VERSION = '1.2.0'
 ISRELEASED = True
 __version__ = VERSION
 # #########################


### PR DESCRIPTION
Beginning work on 1.2 release, which exposes some softcore parameters as `Context` parameters and improves default softcore choices to better match legacy YANK.  Exposing softcore parameters will help automate the identification of optimal paths.

The context parameters created are:
- `softcore_alpha` - factor controlling softcore lengthscale for Lennard-Jones
- `softcore_beta` - squared-distance controlling softcore lengthscale for Coulomb
- `softcore_a` - softcore Lennard-Jones parameter from Eq. 13 of Ref [1]
- `softcore_b` - softcore Lennard-Jones parameter from Eq. 13 of Ref [1]
- `softcore_c` - softcore Lennard-Jones parameter from Eq. 13 of Ref [1]

References:

```
[1] Pham TT and Shirts MR. Identifying low variance pathways for free energy calculations of molecular transformations in solution phase.
JCP 135:034114, 2011. http://dx.doi.org/10.1063/1.3607597
```
