### PR TITLE
[WIP] Overhaul treatment of nonbonded exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/choderalab/alchemy.svg?branch=master)](https://travis-ci.org/choderalab/alchemy)
-[![Anaconda Badge](https://binstar.org/omnia/alchemy/badges/version.svg)](https://binstar.org/omnia/alchemy)
+[![Anaconda Badge](https://anaconda.org/omnia/alchemy/badges/version.svg)](https://anaconda.org/omnia/alchemy)
 
 # Alchemical tools for OpenMM
 

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -789,10 +789,10 @@ class AbsoluteAlchemicalFactory(object):
 
         # Add newly-populated forces to system.
         force_index = system.addForce(force)
-        force_labels[force_index] = 'unmodified PeriodicTorsionForce'
+        force_labels['unmodified PeriodicTorsionForce'] = force_index
 
         force_index = system.addForce(custom_force)
-        force_labels[force_index] = 'alchemically modified PeriodicTorsionForce'
+        force_labels['alchemically modified PeriodicTorsionForce'] = force_index
 
     def _alchemicallyModifyHarmonicAngleForce(self, system, reference_force, force_labels):
         """
@@ -831,10 +831,10 @@ class AbsoluteAlchemicalFactory(object):
 
         # Add newly-populated forces to system.
         force_index = system.addForce(force)
-        force_labels[force_index] = 'unmodified HarmonicAngleForce'
+        force_labels['unmodified HarmonicAngleForce'] = force_index
 
         force_index = system.addForce(custom_force)
-        force_labels[force_index] = 'alchemically modified HarmonicAngleForce'
+        force_labels['alchemically modified HarmonicAngleForce'] = force_index
 
     def _alchemicallyModifyHarmonicBondForce(self, system, reference_force, force_labels):
         """
@@ -1377,7 +1377,7 @@ class AbsoluteAlchemicalFactory(object):
                 force = copy.deepcopy(reference_force)
                 force_index = system.addForce(force)
                 force_name = force.__class__.__name__
-                force_labels[force_index] = 'unmodified %s' % force_name
+                force_labels['unmodified %s' % force_name] = force_index
 
         # Record timing statistics.
         final_time = time.time()
@@ -1466,7 +1466,7 @@ class AbsoluteAlchemicalFactory(object):
         context.setPositions(positions)
         # Get energy component  s
         from collections import OrderedDict
-        energy_components = OderedDict()
+        energy_components = OrderedDict()
         for (force_label, force_index) in self.force_labels.items():
             energy_components[force_label] = context.getState(getEnergy=True,groups=2**force_index).getPotentialEnergy()
         # Clean up

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -307,6 +307,21 @@ def test_denihilated_states(platform_name=None, precision=None):
     if (abs(delta) > MAX_DELTA):
         raise Exception("Maximum allowable difference lambda=1 energy and lambda=0 energy in vacuum and periodic box exceeded (was %.8f kcal/mol; allowed %.8f kcal/mol); test failed." % (delta / unit.kilocalories_per_mole, MAX_DELTA / unit.kilocalories_per_mole))
 
+def check_interacting_energy_components(factory, positions):
+    """Compare full and alchemically-modified system energies by energy component.
+
+    Parameters
+    ----------
+    factory : AbsoluteAlchemicalFactory
+        The factory to test.
+    positions : simtk.openmm.unit.Quantity of dimension [nparticles,3] with units compatible with Angstroms
+        The positions to test.
+
+    """
+    # TODO: Compare total energies for each category with original fully-interacting system.
+
+    pass
+
 def check_noninteracting_energy_components(factory, positions):
     """Check noninteracting energy components are zero when appropriate.
 
@@ -319,7 +334,7 @@ def check_noninteracting_energy_components(factory, positions):
 
     """
     alchemical_state = factory.NoninteractingAlchemicalState()
-    energy_components = factory.getEnergyComponents(alchemical_state, positions, use_all_parameters=True)
+    energy_components = factory.getEnergyComponents(alchemical_state, positions, use_all_parameters=False)
     energy_unit = unit.kilojoule_per_mole
     print(energy_components)
 
@@ -412,13 +427,17 @@ def alchemical_factory_check(reference_system, positions, platform_name=None, pr
         platform = openmm.Platform.getPlatformByName(platform_name)
     alchemical_system = factory.createPerturbedSystem()
 
-    # Compare energies for fully-interacting system
-    print('compare system energies...')
-    compareSystemEnergies(positions, [reference_system, alchemical_system], ['reference', 'alchemical'], platform=platform, precision=precision)
+    # Check energies for fully interacting system.
+    print('check fully interacting interacting energy components...')
+    check_interacting_energy_components(factory, positions)
 
     # Check energies for noninteracting system.
     print('check noninteracting energy components...')
     check_noninteracting_energy_components(factory, positions)
+
+    # Compare energies for fully-interacting system
+    print('compare system energies...')
+    compareSystemEnergies(positions, [reference_system, alchemical_system], ['reference', 'alchemical'], platform=platform, precision=precision)
 
     return
 

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -931,7 +931,7 @@ def test_alchemical_functions():
 
 def test_softcore_parameters():
     """
-    Testing alchemical slave functions
+    Testing softcore parameters
     """
     alchemical_functions = { 'lambda_sterics' : 'lambda', 'lambda_electrostatics' : 'lambda', 'lambda_bonds' : 'lambda', 'lambda_angles' : 'lambda', 'lambda_torsions' : 'lambda' }
     name = 'Lennard-Jones fluid with dispersion correction'

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(name='alchemy',
       zip_safe=False,
       ext_modules=extensions,
       install_requires=[
-        'openmm >=7.0.1',
+        'openmm',
         'numpy',
         ],
       )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def find_package_data(data_root, package_root):
 
 
 # #########################
-VERSION = '1.2.0'
+VERSION = '1.3.0'
 ISRELEASED = True
 __version__ = VERSION
 # #########################
@@ -56,11 +56,11 @@ Operating System :: POSIX
 Operating System :: Unix
 Operating System :: MacOS
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
 """
 
 extensions = []
@@ -79,7 +79,7 @@ setup(name='alchemy',
       zip_safe=False,
       ext_modules=extensions,
       install_requires=[
-        'openmm >=6.3',
+        'openmm >=7.0.1',
         'numpy',
         ],
       )


### PR DESCRIPTION
This PR overhauls the treatment of nonbonded exceptions to treat some fairly significant deficiencies in how decoupled sterics and electrostatics were implemented.

The current implementation---which is far from optimal---moves decoupled intra-alchemical interactions over to `CustomBondForce` terms.

I've also now split the `CustomBondForce`---which previously used a single force for both electrostatics and sterics---into two separate forces in order to better test them.
