### PR TITLE
Update as critical bugfix release instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ systems = factory.createPerturbedSystems(protocol)
 
 ## Changelog
 
-### 1.3 - Overhaul exceptions and testing
+### 1.2.1 - Critical bugfix release and overhaul of exceptions and testing
 This version overhauls the way exceptions are handled, fixing a variety of issues present in earlier versions.
 More thorough testing of fully-interacting and non-interacting systems is implemented, though not all tests run on travis.
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def find_package_data(data_root, package_root):
 
 
 # #########################
-VERSION = '1.3.0'
+VERSION = '1.2.1'
 ISRELEASED = True
 __version__ = VERSION
 # #########################


### PR DESCRIPTION
This should probably be a critical bugfix release instead of a feature release.
