### PR TITLE
[WIP] Add benchmarking script

### DIFF
--- a/alchemy/__init__.py
+++ b/alchemy/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
 
 from .alchemy import *
-
-
+from .utils import *

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -1108,6 +1108,11 @@ overlap_testsystem_names = [
     'toluene in implicit solvent',
 ]
 
+overlap_testsystem_names = [
+    'HostGuest in explicit solvent with PME',
+    'TIP3P with PME, no switch, no dispersion correction', # PME still lacks reciprocal space component; known energy comparison failure
+]
+
 test_systems = dict()
 
 # Generate host-guest test systems combinatorially.
@@ -1206,6 +1211,10 @@ test_systems['TIP3P with PME, no switch, no dispersion correction'] = {
 test_systems['TIP3P with PME, no switch, no dispersion correction, no alchemical atoms'] = {
     'test' : testsystems.WaterBox(dispersion_correction=False, switch=False, nonbondedMethod=app.PME),
     'factory_args' : {'ligand_atoms' : [], 'receptor_atoms' : [] }}
+
+test_systems['HostGuest in explicit solvent with PME'] = {
+    'test' : testsystems.HostGuestExplicit(nonbondedCutoff=9.0*unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, switch_width=1.5*unit.angstroms, ewaldErrorTolerance=1.0e-6),
+    'factory_args' : {'ligand_atoms' : range(126,156), 'receptor_atoms' : range(0,126) }}
 
 test_systems['toluene in implicit solvent'] = {
     'test' : testsystems.TolueneImplicit(),

--- a/alchemy/utils.py
+++ b/alchemy/utils.py
@@ -53,6 +53,7 @@ def benchmark(reference_system, positions, platform_name=None, nsteps=500, times
        Arguments passed to AbsoluteAlchemicalFactory.
 
     """
+    from alchemy import AbsoluteAlchemicalFactory, AlchemicalState
 
     # Create a factory to produce alchemical intermediates.
     logger.info("Creating alchemical factory...")

--- a/alchemy/utils.py
+++ b/alchemy/utils.py
@@ -1,0 +1,142 @@
+#!/usr/bin/python
+
+#=============================================================================================
+# MODULE DOCSTRING
+#=============================================================================================
+
+"""
+Utility functions
+
+"""
+
+#=============================================================================================
+# GLOBAL IMPORTS
+#=============================================================================================
+
+import numpy as np
+import copy
+import time
+import itertools
+
+from simtk import openmm, unit
+import openmmtools
+import argparse
+
+import logging
+logger = logging.getLogger(__name__)
+
+#=============================================================================================
+# PARAMETERS
+#=============================================================================================
+
+#=============================================================================================
+# MODULE UTILITIES
+#=============================================================================================
+
+def benchmark(reference_system, positions, platform_name=None, nsteps=500, timestep=1.0*unit.femtoseconds, factory_args=None):
+    """
+    Benchmark performance of alchemically modified system relative to original system.
+
+    Parameters
+    ----------
+    reference_system : simtk.openmm.System
+       The reference System object to compare with
+    positions : simtk.unit.Quantity with units compatible with nanometers
+       The positions to assess energetics for.
+    platform_name : str, optional, default=None
+       The name of the platform to use for benchmarking.
+    nsteps : int, optional, default=500
+       Number of molecular dynamics steps to use for benchmarking.
+    timestep : simtk.unit.Quantity with units compatible with femtoseconds, optional, default=1*femtoseconds
+       Timestep to use for benchmarking.
+    factory_args : dict(), optional, default=None
+       Arguments passed to AbsoluteAlchemicalFactory.
+
+    """
+
+    # Create a factory to produce alchemical intermediates.
+    logger.info("Creating alchemical factory...")
+    initial_time = time.time()
+    factory = AbsoluteAlchemicalFactory(reference_system, **factory_args)
+    final_time = time.time()
+    elapsed_time = final_time - initial_time
+    logger.info("AbsoluteAlchemicalFactory initialization took %.3f s" % elapsed_time)
+
+    # Create an alchemically-perturbed state corresponding to nearly fully-interacting.
+    # NOTE: We use a lambda slightly smaller than 1.0 because the AlchemicalFactory does not use Custom*Force softcore versions if lambda = 1.0 identically.
+    lambda_value = 1.0 - 1.0e-6
+    alchemical_state = AlchemicalState(lambda_electrostatics=lambda_value, lambda_sterics=lambda_value, lambda_torsions=lambda_value)
+
+    platform = None
+    if platform_name:
+        platform = openmm.Platform.getPlatformByName(platform_name)
+
+    # Create the perturbed system.
+    logger.info("Creating alchemically-modified state...")
+    initial_time = time.time()
+    alchemical_system = factory.createPerturbedSystem(alchemical_state)
+    final_time = time.time()
+    elapsed_time = final_time - initial_time
+    # Compare energies.
+    logger.info("Computing reference energies...")
+    reference_integrator = openmm.VerletIntegrator(timestep)
+    if platform:
+        reference_context = openmm.Context(reference_system, reference_integrator, platform)
+    else:
+        reference_context = openmm.Context(reference_system, reference_integrator)
+    reference_context.setPositions(positions)
+    reference_state = reference_context.getState(getEnergy=True)
+    reference_potential = reference_state.getPotentialEnergy()
+    logger.info("Computing alchemical energies...")
+    alchemical_integrator = openmm.VerletIntegrator(timestep)
+    if platform:
+        alchemical_context = openmm.Context(alchemical_system, alchemical_integrator, platform)
+    else:
+        alchemical_context = openmm.Context(alchemical_system, alchemical_integrator)
+    alchemical_context.setPositions(positions)
+    alchemical_state = alchemical_context.getState(getEnergy=True)
+    alchemical_potential = alchemical_state.getPotentialEnergy()
+    delta = alchemical_potential - reference_potential
+
+    # Make sure all kernels are compiled.
+    reference_integrator.step(2)
+    alchemical_integrator.step(2)
+
+    # Time simulations.
+    logger.info("Simulating reference system...")
+    initial_time = time.time()
+    reference_integrator.step(nsteps)
+    reference_state = reference_context.getState(getEnergy=True)
+    reference_potential = reference_state.getPotentialEnergy()
+    final_time = time.time()
+    reference_time = final_time - initial_time
+    logger.info("Simulating alchemical system...")
+    initial_time = time.time()
+    alchemical_integrator.step(nsteps)
+    alchemical_state = alchemical_context.getState(getEnergy=True)
+    alchemical_potential = alchemical_state.getPotentialEnergy()
+    final_time = time.time()
+    alchemical_time = final_time - initial_time
+
+    logger.info("TIMINGS")
+    logger.info("reference system       : %12.3f s for %8d steps (%12.3f ms/step)" % (reference_time, nsteps, reference_time/nsteps*1000))
+    logger.info("alchemical system      : %12.3f s for %8d steps (%12.3f ms/step)" % (alchemical_time, nsteps, alchemical_time/nsteps*1000))
+    logger.info("alchemical simulation is %12.3f x slower than unperturbed system" % (alchemical_time / reference_time))
+
+    return delta
+
+def run_benchmark():
+    """
+    Benchmark fully interacting system versus alchemically-modified system.
+    """
+    import argparse
+    parser = argparse.ArgumentParser(description='Benchmark alchemically modified system against unmodified system.')
+    parser.add_argument('--platform', dest='platform_name', action='store', default=None, help='platform name to benchmark (default: None)')
+    options = parser.parse_args()
+
+    from sams.tests import testsystems
+    for testsystem_name in ['AblImatinibExplicitAlchemical']:
+        cls = getattr(testsystems, testsystem_name)
+        testsystem = cls()
+        factory_args = { 'ligand_atoms' : testsystem.alchemical_atoms, 'receptor_atoms' : range(0,4266) }
+        benchmark(testsystem.system, testsystem.positions, platform_name=options.platform_name, nsteps=5000, timestep=2.0*unit.femtoseconds, factory_args=factory_args)

--- a/alchemy/utils.py
+++ b/alchemy/utils.py
@@ -56,12 +56,12 @@ def benchmark(reference_system, positions, platform_name=None, nsteps=500, times
     from alchemy import AbsoluteAlchemicalFactory, AlchemicalState
 
     # Create a factory to produce alchemical intermediates.
-    logger.info("Creating alchemical factory...")
+    print("Creating alchemical factory...")
     initial_time = time.time()
     factory = AbsoluteAlchemicalFactory(reference_system, **factory_args)
     final_time = time.time()
     elapsed_time = final_time - initial_time
-    logger.info("AbsoluteAlchemicalFactory initialization took %.3f s" % elapsed_time)
+    print("AbsoluteAlchemicalFactory initialization took %.3f s" % elapsed_time)
 
     # Create an alchemically-perturbed state corresponding to nearly fully-interacting.
     # NOTE: We use a lambda slightly smaller than 1.0 because the AlchemicalFactory does not use Custom*Force softcore versions if lambda = 1.0 identically.
@@ -73,13 +73,13 @@ def benchmark(reference_system, positions, platform_name=None, nsteps=500, times
         platform = openmm.Platform.getPlatformByName(platform_name)
 
     # Create the perturbed system.
-    logger.info("Creating alchemically-modified state...")
+    print("Creating alchemically-modified state...")
     initial_time = time.time()
     alchemical_system = factory.createPerturbedSystem(alchemical_state)
     final_time = time.time()
     elapsed_time = final_time - initial_time
     # Compare energies.
-    logger.info("Computing reference energies...")
+    print("Computing reference energies...")
     reference_integrator = openmm.VerletIntegrator(timestep)
     if platform:
         reference_context = openmm.Context(reference_system, reference_integrator, platform)
@@ -88,7 +88,7 @@ def benchmark(reference_system, positions, platform_name=None, nsteps=500, times
     reference_context.setPositions(positions)
     reference_state = reference_context.getState(getEnergy=True)
     reference_potential = reference_state.getPotentialEnergy()
-    logger.info("Computing alchemical energies...")
+    print("Computing alchemical energies...")
     alchemical_integrator = openmm.VerletIntegrator(timestep)
     if platform:
         alchemical_context = openmm.Context(alchemical_system, alchemical_integrator, platform)
@@ -104,14 +104,14 @@ def benchmark(reference_system, positions, platform_name=None, nsteps=500, times
     alchemical_integrator.step(2)
 
     # Time simulations.
-    logger.info("Simulating reference system...")
+    print("Simulating reference system...")
     initial_time = time.time()
     reference_integrator.step(nsteps)
     reference_state = reference_context.getState(getEnergy=True)
     reference_potential = reference_state.getPotentialEnergy()
     final_time = time.time()
     reference_time = final_time - initial_time
-    logger.info("Simulating alchemical system...")
+    print("Simulating alchemical system...")
     initial_time = time.time()
     alchemical_integrator.step(nsteps)
     alchemical_state = alchemical_context.getState(getEnergy=True)
@@ -119,10 +119,12 @@ def benchmark(reference_system, positions, platform_name=None, nsteps=500, times
     final_time = time.time()
     alchemical_time = final_time - initial_time
 
-    logger.info("TIMINGS")
-    logger.info("reference system       : %12.3f s for %8d steps (%12.3f ms/step)" % (reference_time, nsteps, reference_time/nsteps*1000))
-    logger.info("alchemical system      : %12.3f s for %8d steps (%12.3f ms/step)" % (alchemical_time, nsteps, alchemical_time/nsteps*1000))
-    logger.info("alchemical simulation is %12.3f x slower than unperturbed system" % (alchemical_time / reference_time))
+    seconds_per_day = (1.*unit.day)/(1.*unit.seconds)
+
+    print("TIMINGS")
+    print("reference system       : %12.3f s for %8d steps (%12.3f ms/step; %12.3f ns/day)" % (reference_time, nsteps, reference_time/nsteps*1000, nsteps*timestep*(seconds_per_day/reference_time)/unit.nanoseconds))
+    print("alchemical system      : %12.3f s for %8d steps (%12.3f ms/step; %12.3f ns/day)" % (alchemical_time, nsteps, alchemical_time/nsteps*1000, nsteps*timestep*(seconds_per_day/alchemical_time)/unit.nanoseconds))
+    print("alchemical simulation is %12.3f x slower than unperturbed system" % (alchemical_time / reference_time))
 
     return delta
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,11 @@ setup(name='alchemy',
       #package_data={'alchemy' : find_package_data('alchemy','examples')},
       zip_safe=False,
       ext_modules=extensions,
+      entry_points = {
+        'console_scripts' : [
+            'alchemy-benchmark = alchemy.utils:run_benchmark'
+        ]
+      },
       install_requires=[
         'openmm',
         'numpy',


### PR DESCRIPTION
This is the start of a script that benchmarks the alchemically-modified version of a system against the fully-interacting version. Currently, only one test system is supported, and this test system requires the `sams` project, but eventually we'll have a number of useful alchemical test systems compiled somewhere.

Initial results for Abl:imatinib in explicit solvent with PME:

```
TIMINGS (CUDA)
reference system       :        9.176 s for     5000 steps (       1.835 ms/step;       94.156 ns/day)
alchemical system      :       11.468 s for     5000 steps (       2.294 ms/step;       75.343 ns/day)
alchemical simulation is        1.250 x slower than unperturbed system
```

Not too bad. I had expected there would be a much bigger slowdown for the alchemically-modified system.
