### PR TITLE
[WIP] Add support for alchemically-modified CustomGBForces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   # Install the package
   - conda install --yes --use-local alchemy-dev
   # Install testing dependencies
-  - conda install --yes --quiet nose nose-timer click netcdf4 pymbar openmmtools
+  - conda install --yes --quiet nose nose-timer click netcdf4 pymbar openmmtools>=0.8.3
   # Test the package
   - cd devtools && nosetests $PACKAGENAME --nocapture --nologcapture --verbosity=2 --with-doctest --with-timer -a '!slow' && cd ..
 

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -1513,7 +1513,7 @@ class AbsoluteAlchemicalFactory(object):
         for function_index in range(reference_force.getNumTabulatedFunctions()):
             name = reference_force.getTabulatedFunctionName(function_index)
             function = reference_force.getTabulatedFunction(function_index)
-            function_copy = copy.deepcopy(function)
+            function_copy = function.Copy()
             custom_force.addTabulatedFunction(name, function_copy)
 
         # Add alchemically-modified CustomGBForce to system

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -1498,9 +1498,8 @@ class AbsoluteAlchemicalFactory(object):
 
             custom_force.addEnergyTerm(expression, computation_type)
 
-        # Add particle parameters.
+        # Add particle parameters
         for particle_index in range(reference_force.getNumParticles()):
-            # Retrieve parameters.
             parameters = reference_force.getParticleParameters(particle_index)
             # Append alchemical parameter
             parameters = list(parameters)
@@ -1510,7 +1509,14 @@ class AbsoluteAlchemicalFactory(object):
                 parameters.append(0.0)
             custom_force.addParticle(parameters)
 
-        # Add alchemically-modified CustomGBForce to system.
+        # Add tabulated functions
+        for function_index in range(reference_force.getNumTabulatedFunctions()):
+            name = reference_force.getTabulatedFunctionName(function_index)
+            function = reference_force.getTabulatedFunction(function_index)
+            function_copy = copy.deepcopy(function)
+            custom_force.addTabulatedFunction(name, function_copy)
+
+        # Add alchemically-modified CustomGBForce to system
         force_index = system.addForce(custom_force)
         force_labels['alchemically modified CustomGBForce'] = force_index
 

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -1516,6 +1516,11 @@ class AbsoluteAlchemicalFactory(object):
             function_copy = function.Copy()
             custom_force.addTabulatedFunction(name, function_copy)
 
+        # Add exclusions
+        for exclusion_index in range(reference_force.getNumExclusions()):
+            [particle1, particle2] = reference_force.getExclusionParticles(exclusion_index)
+            custom_force.addExclusion(particle1, particle2)
+
         # Add alchemically-modified CustomGBForce to system
         force_index = system.addForce(custom_force)
         force_labels['alchemically modified CustomGBForce'] = force_index

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -1488,7 +1488,7 @@ class AbsoluteAlchemicalFactory(object):
 
             # Alter expressions
             if (computation_type == openmm.CustomGBForce.SingleParticle):
-                prepend = 'alchemical_scaling*unscaled; alchemical_scaling = (lambda_electrostatics*alchemical2 + (1-alchemical2)); unscaled = '
+                prepend = 'alchemical_scaling*unscaled; alchemical_scaling = (lambda_electrostatics*alchemical + (1-alchemical)); unscaled = '
                 expression = prepend + expression
             else:
                 expression.replace('charge1', 'alchemically_scaled_charge1')

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -1503,7 +1503,7 @@ class AbsoluteAlchemicalFactory(object):
             # Retrieve parameters.
             parameters = reference_force.getParticleParameters(particle_index)
             # Append alchemical parameter
-            parameter = list(parameters)
+            parameters = list(parameters)
             if particle_index in self.ligand_atoms:
                 parameters.append(1.0)
             else:

--- a/alchemy/alchemy.py
+++ b/alchemy/alchemy.py
@@ -311,7 +311,7 @@ class AbsoluteAlchemicalFactory(object):
         # If no ligand atom set is specified, create an empty list.
         if ligand_atoms is None:
             ligand_atoms = list()
-        
+
         # Ligand atoms must be list of numpy int type
         ligand_atoms = [ int(index) for index in ligand_atoms ]
 
@@ -1370,11 +1370,6 @@ class AbsoluteAlchemicalFactory(object):
         sasa_model : str, optional, default='ACE'
             Solvent accessible surface area model.
 
-        TODO
-        ----
-        * Add support for all types of GBSA forces supported by OpenMM.
-        * Can we more generally modify any CustomGBSAForce?
-
         """
 
         custom_force = openmm.CustomGBForce()
@@ -1427,6 +1422,98 @@ class AbsoluteAlchemicalFactory(object):
         force_index = system.addForce(custom_force)
         force_labels['alchemically modified GBSAOBCForce'] = force_index
 
+    def _alchemicallyModifyCustomGBForce(self, system, reference_force, force_labels):
+        """
+        Create alchemically-modified version of CustomGBForce by metaprogramming GB functions.
+
+        The following rules are applied:
+        - 'lambda_electrostatics' is added as a global parameter.
+        - 'alchemical' is added as a per-particle parameter.
+           All atoms in the alchemical group have this parameter set to 1; otherwise 0.
+        - Any single-particle energy term (`CustomGBForce.SingleParticle`) is scaled by `(lambda_electrostatics*alchemical+(1-alchemical))`
+        - Any two-particle energy term (`CustomGBForce.ParticlePairNoExclusions`) has charge 1 (`charge1`) replaced by `(lambda_electrostatics*alchemical1+(1-alchemical1))*charge1` and charge 2 (`charge2`) replaced by `(lambda_electrostatics*alchemical2+(1-alchemical2))*charge2`.
+        - Any single-particle computed value (`CustomGBForce.SingleParticle`) remains unmodified
+        - Any two-particle computed value (`CustomGBForce.ParticlePairNoExclusions`) is scaled by `(lambda_electrostatics*alchemical2 + (1-alchemical2))`
+
+        Scaling of a term should always prepend and capture the value with an intermediate variable.
+        For example, prepending `scaling * unscaled; unscaled =` will capture the value of the expression as `unscaled` and multiple by `scaled`.
+        This avoids the need to identify the head expression and add parentheses.
+
+        WARNING: This may not work correctly for all GB models.
+
+        Parameters
+        ----------
+        system : simtk.openmm.System
+            Alchemically-modified System object being built.  This object will be modified.
+        reference_force : simtk.openmm.GBSAOBCForce
+            Reference force to use for template.
+        force_labels : dict of int : str
+            force_labels[name] is the force index in the alchemically modified system of the modified force `name`
+
+        """
+
+        custom_force = openmm.CustomGBForce()
+
+        # Add global parameters
+        for index in range(reference_force.getNumGlobalParameters()):
+            name = reference_force.getGlobalParameterName(index)
+            default_value = reference_force.getGlobalParameterDefaultValue(index)
+            custom_force.addGlobalParameter(name, default_value)
+        custom_force.addGlobalParameter("lambda_electrostatics", 1.0);
+
+        # Add per-particle parameters.
+        for index in range(reference_force.getNumPerParticleParameters()):
+            name = reference_force.getPerParticleParameterName(index)
+            custom_force.addPerParticleParameter(name)
+        custom_force.addPerParticleParameter("alchemical");
+
+        # Set nonbonded methods.
+        custom_force.setNonbondedMethod(reference_force.getNonbondedMethod())
+        custom_force.setCutoffDistance(reference_force.getCutoffDistance())
+
+        # Add computations.
+        for index in range(reference_force.getNumComputedValues()):
+            [name, expression, computation_type] = reference_force.getComputedValueParameters(index)
+
+            # Alter expression for particle pair terms only.
+            if not (computation_type == openmm.CustomGBForce.SingleParticle):
+                prepend = 'alchemical_scaling*unscaled; alchemical_scaling = (lambda_electrostatics*alchemical2 + (1-alchemical2)); unscaled = '
+                expression = prepend + expression
+
+            custom_force.addComputedValue(name, expression, computation_type)
+
+        # Add energy terms.
+        for index in range(reference_force.getNumEnergyTerms()):
+            [expression, computation_type] = reference_force.getEnergyTermParameters(index)
+
+            # Alter expressions
+            if (computation_type == openmm.CustomGBForce.SingleParticle):
+                prepend = 'alchemical_scaling*unscaled; alchemical_scaling = (lambda_electrostatics*alchemical2 + (1-alchemical2)); unscaled = '
+                expression = prepend + expression
+            else:
+                expression.replace('charge1', 'alchemically_scaled_charge1')
+                expression.replace('charge2', 'alchemically_scaled_charge2')
+                expression += ' ; alchemically_scaled_charge1 = (lambda_electrostatics*alchemical1+(1-alchemical1)) * charge1;'
+                expression += ' ; alchemically_scaled_charge2 = (lambda_electrostatics*alchemical2+(1-alchemical2)) * charge2;'
+
+            custom_force.addEnergyTerm(expression, computation_type)
+
+        # Add particle parameters.
+        for particle_index in range(reference_force.getNumParticles()):
+            # Retrieve parameters.
+            parameters = reference_force.getParticleParameters(particle_index)
+            # Append alchemical parameter
+            parameter = list(parameters)
+            if particle_index in self.ligand_atoms:
+                parameters.append(1.0)
+            else:
+                parameters.append(0.0)
+            custom_force.addParticle(parameters)
+
+        # Add alchemically-modified CustomGBForce to system.
+        force_index = system.addForce(custom_force)
+        force_labels['alchemically modified CustomGBForce'] = force_index
+
     def _createAlchemicallyModifiedSystem(self, mm=None):
         """
         Create an alchemically modified version of the reference system with global parameters encoding alchemical parameters.
@@ -1445,6 +1532,8 @@ class AbsoluteAlchemicalFactory(object):
           Use class names instead.
 
         """
+        # TODO: Check that the provided system hasn't already been alchemically modified.
+        # We don't want to allow a System to be modified twice!
 
         # Record timing statistics.
         initial_time = time.time()
@@ -1487,6 +1576,8 @@ class AbsoluteAlchemicalFactory(object):
                 self._alchemicallyModifyHarmonicBondForce(system, reference_force, force_labels)
             elif isinstance(reference_force, openmm.NonbondedForce):
                 self._alchemicallyModifyNonbondedForce(system, reference_force, force_labels)
+            elif isinstance(reference_force, openmm.CustomGBForce):
+                self._alchemicallyModifyCustomGBForce(system, reference_force, force_labels)
             elif isinstance(reference_force, openmm.GBSAOBCForce):
                 self._alchemicallyModifyGBSAOBCForce(system, reference_force, force_labels)
             elif isinstance(reference_force, openmm.AmoebaMultipoleForce):

--- a/alchemy/tests/test_alchemy.py
+++ b/alchemy/tests/test_alchemy.py
@@ -1311,8 +1311,14 @@ test_systems['alanine dipeptide in OBC GBSA, with sterics annihilated'] = {
 test_systems['alanine dipeptide in TIP3P with reaction field'] = {
     'test' : testsystems.AlanineDipeptideExplicit(nonbondedMethod=app.CutoffPeriodic),
     'factory_args' : {'ligand_atoms' : range(0,22), 'receptor_atoms' : range(22,22) }}
-test_systems['T4 lysozyme L99A with p-xylene in OBC GBSA'] = {
-    'test' : testsystems.LysozymeImplicit(),
+test_systems['T4 lysozyme L99A with p-xylene in OBC1 GBSA'] = {
+    'test' : testsystems.LysozymeImplicit(implicitSolvent=app.OBC1),
+    'factory_args' : {'ligand_atoms' : range(2603,2621), 'receptor_atoms' : range(0,2603) }}
+test_systems['T4 lysozyme L99A with p-xylene in OBC2 GBSA'] = {
+    'test' : testsystems.LysozymeImplicit(implicitSolvent=app.OBC2),
+    'factory_args' : {'ligand_atoms' : range(2603,2621), 'receptor_atoms' : range(0,2603) }}
+test_systems['T4 lysozyme L99A with p-xylene in GBn2 GBSA'] = {
+    'test' : testsystems.LysozymeImplicit(implicitSolvent=app.GBn2),
     'factory_args' : {'ligand_atoms' : range(2603,2621), 'receptor_atoms' : range(0,2603) }}
 test_systems['DHFR in explicit solvent with reaction field, annihilated'] = {
     'test' : testsystems.DHFRExplicit(nonbondedMethod=app.CutoffPeriodic),
@@ -1331,7 +1337,6 @@ test_systems['Src in GBSA, with Src sterics annihilated'] = {
     'factory_args' : {'ligand_atoms' : range(0,4427), 'receptor_atoms' : [],
     'annihilate_sterics' : True, 'annihilate_electrostatics' : True }}
 
-# Problematic tests: PME is not fully implemented yet
 test_systems['TIP3P with PME, no switch, no dispersion correction'] = {
     'test' : testsystems.WaterBox(dispersion_correction=False, switch=False, nonbondedMethod=app.PME),
     'factory_args' : {'ligand_atoms' : range(0,3), 'receptor_atoms' : range(3,6) }}
@@ -1339,6 +1344,13 @@ test_systems['TIP3P with PME, no switch, no dispersion correction, no alchemical
     'test' : testsystems.WaterBox(dispersion_correction=False, switch=False, nonbondedMethod=app.PME),
     'factory_args' : {'ligand_atoms' : [], 'receptor_atoms' : [] }}
 
+
+test_systems['HostGuest in implicit solvent with OBC1'] = {
+    'test' : testsystems.HostGuestImplicit(implicitSolvent=app.OBC1),
+    'factory_args' : {'ligand_atoms' : range(126,156), 'receptor_atoms' : range(0,126) }}
+test_systems['HostGuest in implicit solvent with OBC2'] = {
+    'test' : testsystems.HostGuestImplicit(implicitSolvent=app.OBC2),
+    'factory_args' : {'ligand_atoms' : range(126,156), 'receptor_atoms' : range(0,126) }}
 test_systems['HostGuest in explicit solvent with PME'] = {
     'test' : testsystems.HostGuestExplicit(nonbondedCutoff=9.0*unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, switch_width=1.5*unit.angstroms, ewaldErrorTolerance=1.0e-6),
     'factory_args' : {'ligand_atoms' : range(126,156), 'receptor_atoms' : range(0,126) }}

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -29,6 +29,7 @@ test:
     - click
     - netcdf4
     - pymbar
+    - openmmtools
 
   imports:
     - alchemy


### PR DESCRIPTION
Addresses #22.

This is a first pass at adding support for additional GBSA models encoded as `CustomGBForce` objects. 

I am using some new testsystem options I added to `openmmtools` in https://github.com/choderalab/openmmtools/pull/123, so travis testing will have to await cutting a new release.